### PR TITLE
PlaceOrders fix, CancelOrders added

### DIFF
--- a/betfair.go
+++ b/betfair.go
@@ -4,7 +4,7 @@ package betting
 type BetfairRestURL string
 
 const (
-	CertURL                     = "https://identitysso-api.betfair.com/api/certlogin"
+	CertURL                     = "https://identitysso-cert.betfair.com/api/certlogin"
 	KeepAliveURL                = "https://identitysso.betfair.com/api/keepAlive"
 	AccountURL   BetfairRestURL = "https://api.betfair.com/exchange/account/rest/v1.0"
 	BettingURL   BetfairRestURL = "https://api.betfair.com/exchange/betting/rest/v1.0"

--- a/betting.go
+++ b/betting.go
@@ -25,6 +25,7 @@ func (b *Betting) Request(reqStruct interface{}, url BetfairRestURL, method stri
 	req.SetRequestURI(urlBuild.String())
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Connection","keep-alive")
 	req.Header.Set("X-Application", b.ApiKey)
 	req.Header.Set("X-Authentication", b.SessionKey)
 	req.Header.SetMethod("POST")

--- a/betting.go
+++ b/betting.go
@@ -35,7 +35,7 @@ func (b *Betting) Request(reqStruct interface{}, url BetfairRestURL, method stri
 			return err
 		}
 
-		fmt.Println(string(filterBody))
+//		fmt.Println(string(filterBody))
 
 		req.SetBody(filterBody)
 	}

--- a/betting.go
+++ b/betting.go
@@ -13,7 +13,7 @@ type Betting struct {
 }
 
 // Request function for send requests to betfair via REST JSON
-func (b *Betting) Request(reqStruct interface{}, url BetfairRestURL, method string, filter *Filter) error {
+func (b *Betting) Request(reqStruct interface{}, url BetfairRestURL, method string, filter interface{}) error {
 	req, resp := fasthttp.AcquireRequest(), fasthttp.AcquireResponse()
 
 	urlBuild := bytes.NewBuffer([]byte{})

--- a/betting_order.go
+++ b/betting_order.go
@@ -1,11 +1,21 @@
 package betting
 
-import "time"
+import (
+	"time"
+	"fmt"
+)
+
+
+type Decimal float64
+
+func (n Decimal) MarshalJSON() ([]byte, error) {
+    return []byte(fmt.Sprintf("%.2f", n)), nil
+}
 
 type PlaceInstruction struct {
 	OrderType          EOrderType         `json:"orderType,omitempty"`
 	SelectionID        int64              `json:"selectionId,omitempty"`
-	Handicap           float64            `json:"handicap"`
+	Handicap           Decimal            `json:"handicap,omitempty"`
 	Side               ESide              `json:"side,omitempty"`
 	LimitOrder         LimitOrder         `json:"limitOrder,omitempty"`
 	LimitOnCloseOrder  LimitOnCloseOrder  `json:"limitOnCloseOrder,omitempty"`
@@ -33,22 +43,22 @@ type PlaceInstructionReport struct {
 }
 
 type LimitOrder struct {
-	Size            float64          `json:"size,omitempty"`
-	Price           float64          `json:"price,omitempty"`
+	Size            Decimal          `json:"size,omitempty"`
+	Price           Decimal          `json:"price,omitempty"`
 	PersistenceType EPersistenceType `json:"persistenceType,omitempty"`
 	TimeInForce     ETimeInForce     `json:"timeInForce,omitempty"`
-	MinFillSize     float64          `json:"minFillSize,omitempty"`
+	MinFillSize     Decimal          `json:"minFillSize,omitempty"`
 	BetTargetType   EBetTargetType   `json:"betTargetType,omitempty"`
-	BetTargetSize   float64          `json:"betTargetSize,omitempty"`
+	BetTargetSize   Decimal          `json:"betTargetSize,omitempty"`
 }
 
 type LimitOnCloseOrder struct {
-	Liability float64 `json:"liability,omitempty"`
-	Price     float64 `json:"price,omitempty"`
+	Liability Decimal `json:"liability,omitempty"`
+	Price     Decimal `json:"price,omitempty"`
 }
 
 type MarketOnCloseOrder struct {
-	Liability float64 `json:"liability,omitempty"`
+	Liability Decimal `json:"liability,omitempty"`
 }
 
 // PlaceOrders to place new orders into market.

--- a/betting_order.go
+++ b/betting_order.go
@@ -17,9 +17,9 @@ type PlaceInstruction struct {
 	SelectionID        int64              `json:"selectionId,omitempty"`
 	Handicap           Decimal            `json:"handicap,omitempty"`
 	Side               ESide              `json:"side,omitempty"`
-	LimitOrder         LimitOrder         `json:"limitOrder,omitempty"`
-	LimitOnCloseOrder  LimitOnCloseOrder  `json:"limitOnCloseOrder,omitempty"`
-	MarketOnCloseOrder MarketOnCloseOrder `json:"marketOnCloseOrder,omitempty"`
+	LimitOrder         *LimitOrder         `json:"limitOrder,omitempty"`
+	LimitOnCloseOrder  *LimitOnCloseOrder  `json:"limitOnCloseOrder,omitempty"`
+	MarketOnCloseOrder *MarketOnCloseOrder `json:"marketOnCloseOrder,omitempty"`
 	CustomerOrderRef   string             `json:"customerOrderRef,omitempty"`
 }
 
@@ -64,6 +64,38 @@ type MarketOnCloseOrder struct {
 // PlaceOrders to place new orders into market.
 func (b *Betting) PlaceOrders(filter Filter) (placeExecutionReport PlaceExecutionReport, err error) {
 	err = b.Request(&placeExecutionReport, BettingURL, "placeOrders", &filter)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+
+type	CancelInstruction	struct	{
+	BetID          string         `json:"betId"`
+	SizeReduction  Decimal        `json:"sizeReduction,omitempty"`
+}
+
+type CancelExecutionReport struct {
+	CustomerRef        string                    `json:"customerRef,omitempty"`
+	Status             EExecutionReportStatus    `json:"status,omitempty"`
+	ErrorCode          EExecutionReportErrorCode `json:"errorCode,omitempty"`
+	MarketID           string                    `json:"marketId,omitempty"`
+	InstructionReports []CancelInstructionReport  `json:"instructionReports,omitempty"`
+}
+
+type CancelInstructionReport struct {
+	Status              EInstructionReportStatus    `json:"status,omitempty"`
+	ErrorCode           EInstructionReportErrorCode `json:"errorCode,omitempty"`
+	Instruction         CancelInstruction            `json:"instruction,omitempty"`
+	CancelledDate       time.Time                   `json:"cancelledDate,omitempty"`
+	SizeCancelled       float64                     `json:"sizeCancelled,omitempty"`
+}
+
+// CancelOrders to place new orders into market.
+func (b *Betting) CancelOrders(filter CancelFilter) (cancelExecutionReport CancelExecutionReport, err error) {
+	err = b.Request(&cancelExecutionReport, BettingURL, "cancelOrders", &filter)
 	if err != nil {
 		return
 	}

--- a/betting_params.go
+++ b/betting_params.go
@@ -65,3 +65,9 @@ type Filter struct {
 	CustomerOrderRefs            []string             `json:"customerOrderRefs,omitempty"`
 	CustomerStrategyRefs         []string             `json:"customerStrategyRefs,omitempty"`
 }
+
+type CancelFilter struct {
+	MarketID                    string             `json:"marketId"`
+	CancelOrdersInstructions	[]CancelInstruction  `json:"instructions"` 		
+	CustomerRef            		string             	`json:"customerRef,omitempty"`
+}


### PR DESCRIPTION
Managed to fix the issue with PlaceOrders I was having.
Seemed to be two issues:
1) Sometimes float64 values result in numbers such as 1.999999999 when being marshalled. BetFair then rejects the request. To fix this I've added a new type Decimal float64, and added a marshalJson method. This is a dirty fix, but replacing any float64s passed to betfair with Decimal seems to have resolved that issue.
2) The PlaceInstruction type contains 3 structs for the different order types. These are set to omitempty but empty structs are still included. The filterbody included "limitOnCloseOrder":{},"marketOnCloseOrder":{} in Instruction data when doing a limitOrder. 
Not sure if this is the same in all versions of Go and ffson?
I've altered the PlaceInstruction type to have pointers to these types which fixes the issue but would require anyone using this library and placing orders to change their programs.
In addition, Ive added types and func for CancelOrders. I couldnt get the ffjson to correctly handle the filter struct when I added the CancelOrdersInstructions as it's json name instructions, is the same as the PlaceOrdersInstructions and the marshal seemed to omit both when one was empty.
For that reason, I've added a CancelFilter and changed the Request routine so the filter is passed as an interface{}.