### PR TITLE
Fix typo in MarketFilter declaration 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@
 
 Greg World <greg@seesawlabs.com>
 Robert Egorov <robert.egorov@gmail.com>
+Ben Magee <btmagee@augurfutures.com>

--- a/betting_filter.go
+++ b/betting_filter.go
@@ -1,19 +1,19 @@
 package betting
 
 type MarketFilter struct {
-	TextQuery          string                `json:"textQuery,omitempty"`
-	ExchangeIDs        []string              `json:"exchangeIds,omitempty"`
-	EventTypeIDs       []string              `json:"eventTypeIds,omitempty"`
-	EventIDs           []string              `json:"eventIds,omitempty"`
-	CompetitionIDs     []string              `json:"competitionIds,omitempty"`
-	MarketIDs          []string              `json:"marketIds,omitempty"`
-	Venues             []string              `json:"venues,omitempty"`
-	BspOnly            *bool                 `json:"bspOnly,omitempty"`
-	TurnInPlayEnabled  *bool                 `json:"turnInPlayEnabled,omitempty"`
-	InPlayOnly         *bool                 `json:"inPlayOnly,omitempty"`
-	MarketBettingTypes []EMarketBettingTypes `json:"marketBettingTypes,omitempty"`
-	MarketCountries    []string              `json:"marketCountries,omitempty"`
-	MarketTypeCodes    []string              `json:"marketTypeCodes,omitempty"`
-	MarketStartTime    *DateRange            `json:"marketStartTime,omitempty"`
-	WithOrders         []EOrderStatus        `json:"withOrders,omitempty"`
+	TextQuery          string               `json:"textQuery,omitempty"`
+	ExchangeIDs        []string             `json:"exchangeIds,omitempty"`
+	EventTypeIDs       []string             `json:"eventTypeIds,omitempty"`
+	EventIDs           []string             `json:"eventIds,omitempty"`
+	CompetitionIDs     []string             `json:"competitionIds,omitempty"`
+	MarketIDs          []string             `json:"marketIds,omitempty"`
+	Venues             []string             `json:"venues,omitempty"`
+	BspOnly            *bool                `json:"bspOnly,omitempty"`
+	TurnInPlayEnabled  *bool                `json:"turnInPlayEnabled,omitempty"`
+	InPlayOnly         *bool                `json:"inPlayOnly,omitempty"`
+	MarketBettingTypes []EMarketBettingType `json:"marketBettingTypes,omitempty"`
+	MarketCountries    []string             `json:"marketCountries,omitempty"`
+	MarketTypeCodes    []string             `json:"marketTypeCodes,omitempty"`
+	MarketStartTime    *DateRange           `json:"marketStartTime,omitempty"`
+	WithOrders         []EOrderStatus       `json:"withOrders,omitempty"`
 }


### PR DESCRIPTION
MarketFilter incorrectly declared that `MarketBettingTypes` was an array of `EMarketBettingTypes`, rather than `EMarketBettingType` (note the extra `s` originally). This serialised to a nested array that Betfair rejected. 

This PR corrects the field declaration such that the serialized JSON is a single array.

Fixes #14 .