### PR TITLE
Parameterize Betfair URLs

### DIFF
--- a/account.go
+++ b/account.go
@@ -21,7 +21,7 @@ type DeveloperAppKey struct {
 
 // CreateAppKeys for create new developer app keys in account
 func (b *Betting) CreateAppKeys() (developAppKeys []DeveloperAppKey, err error) {
-	err = b.Request(&developAppKeys, AccountURL, "createDeveloperAppKeys", nil)
+	err = b.Request(&developAppKeys, b.AccountURL, "createDeveloperAppKeys", nil)
 	if err != nil {
 		return
 	}
@@ -43,7 +43,7 @@ type AccountDetails struct {
 
 // GetAccountDetails like get account details :)
 func (b *Betting) GetAccountDetails() (accountDetails AccountDetails, err error) {
-	err = b.Request(&accountDetails, AccountURL, "getAccountDetails", nil)
+	err = b.Request(&accountDetails, b.AccountURL, "getAccountDetails", nil)
 	if err != nil {
 		return
 	}
@@ -62,7 +62,7 @@ type AccountFunds struct {
 
 // GetAccountFunds for getting balances of account
 func (b *Betting) GetAccountFunds(filter Filter) (accountFunds AccountFunds, err error) {
-	err = b.Request(&accountFunds, AccountURL, "getAccountFunds", &filter)
+	err = b.Request(&accountFunds, b.AccountURL, "getAccountFunds", &filter)
 	if err != nil {
 		return
 	}
@@ -72,7 +72,7 @@ func (b *Betting) GetAccountFunds(filter Filter) (accountFunds AccountFunds, err
 
 // GetAppKeys for getting all developer keys from account
 func (b *Betting) GetAppKeys() (developAppKeys []DeveloperAppKey, err error) {
-	err = b.Request(&developAppKeys, AccountURL, "getDeveloperAppKeys", nil)
+	err = b.Request(&developAppKeys, b.AccountURL, "getDeveloperAppKeys", nil)
 	if err != nil {
 		return
 	}
@@ -118,7 +118,7 @@ type AccountStatementReport struct {
 
 // GetAccountStatement about get account statements for 90 days
 func (b *Betting) GetAccountStatement(filter Filter) (accountStatementReport AccountStatementReport, err error) {
-	err = b.Request(&accountStatementReport, AccountURL, "getAccountStatement", &filter)
+	err = b.Request(&accountStatementReport, b.AccountURL, "getAccountStatement", &filter)
 	if err != nil {
 		return
 	}
@@ -133,7 +133,7 @@ type CurrencyRate struct {
 
 // GetListCurrencyRates for get currency rates for hour
 func (b *Betting) GetListCurrencyRates(filter Filter) (currencyRate []CurrencyRate, err error) {
-	err = b.Request(&currencyRate, AccountURL, "listCurrencyRates", &filter)
+	err = b.Request(&currencyRate, b.AccountURL, "listCurrencyRates", &filter)
 	if err != nil {
 		return
 	}
@@ -147,7 +147,7 @@ type TransferResponse struct {
 
 // GetTransferFunds for transfer funds between UK and AUS wallets
 func (b *Betting) GetTransferFunds(filter Filter) (transferResponse TransferResponse, err error) {
-	err = b.Request(&transferResponse, AccountURL, "transferFunds", &filter)
+	err = b.Request(&transferResponse, b.AccountURL, "transferFunds", &filter)
 	if err != nil {
 		return
 	}

--- a/betfair.go
+++ b/betfair.go
@@ -3,13 +3,13 @@ package betting
 // BetfairRestURL type of all betfair rest urls
 type BetfairRestURL string
 
-const (
-	CertURL                     = "https://identitysso-cert.betfair.com/api/certlogin"
-	KeepAliveURL                = "https://identitysso.betfair.com/api/keepAlive"
-	AccountURL   BetfairRestURL = "https://api.betfair.com/exchange/account/rest/v1.0"
-	BettingURL   BetfairRestURL = "https://api.betfair.com/exchange/betting/rest/v1.0"
-	ScoresURL                   = "https://api.betfair.com/exchange/scores/json-rpc/v1"
-)
+type BetfairRestURLs struct {
+	AccountURL   BetfairRestURL
+	BettingURL   BetfairRestURL
+	CertURL      BetfairRestURL
+	KeepAliveURL BetfairRestURL
+	ScoresURL    BetfairRestURL
+}
 
 type Betfair struct {
 	*Client
@@ -17,12 +17,34 @@ type Betfair struct {
 }
 
 func NewBetfair(apikey string) *Betfair {
+	var defaultAccountURL BetfairRestURL = "https://api.betfair.com/exchange/account/rest/v1.0"
+	var defaultBettingURL BetfairRestURL = "https://api.betfair.com/exchange/betting/rest/v1.0"
+	var defaultCertURL BetfairRestURL = "https://identitysso-cert.betfair.com/api/certlogin"
+	var defaultKeepAliveURL BetfairRestURL = "https://identitysso.betfair.com/api/keepAlive"
+	var defaultScoresURL BetfairRestURL = "https://api.betfair.com/exchange/scores/json-rpc/v1"
 
-	client := Client{ApiKey: apikey}
+	return NewBetfairWithSpecifiedURLs(apikey, BetfairRestURLs{
+		AccountURL:   defaultAccountURL,
+		BettingURL:   defaultBettingURL,
+		CertURL:      defaultCertURL,
+		KeepAliveURL: defaultKeepAliveURL,
+		ScoresURL:    defaultScoresURL,
+	})
+}
+
+func NewBetfairWithSpecifiedURLs(apikey string, urls BetfairRestURLs) *Betfair {
+	client := Client{
+		ApiKey:       apikey,
+		CertURL:      urls.CertURL,
+		KeepAliveURL: urls.KeepAliveURL,
+	}
 
 	return &Betfair{
-		Client:  &client,
-		Betting: &Betting{&client},
+		Client: &client,
+		Betting: &Betting{
+			Client:     &client,
+			BettingURL: urls.BettingURL,
+		},
 	}
 }
 

--- a/betting.go
+++ b/betting.go
@@ -10,6 +10,8 @@ import (
 
 type Betting struct {
 	*Client
+	BettingURL BetfairRestURL
+	AccountURL BetfairRestURL
 }
 
 // Request function for send requests to betfair via REST JSON
@@ -25,7 +27,7 @@ func (b *Betting) Request(reqStruct interface{}, url BetfairRestURL, method stri
 	req.SetRequestURI(urlBuild.String())
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Connection","keep-alive")
+	req.Header.Set("Connection", "keep-alive")
 	req.Header.Set("X-Application", b.ApiKey)
 	req.Header.Set("X-Authentication", b.SessionKey)
 	req.Header.SetMethod("POST")
@@ -36,7 +38,7 @@ func (b *Betting) Request(reqStruct interface{}, url BetfairRestURL, method stri
 			return err
 		}
 
-//		fmt.Println(string(filterBody))
+		//		fmt.Println(string(filterBody))
 
 		req.SetBody(filterBody)
 	}

--- a/betting_list.go
+++ b/betting_list.go
@@ -15,7 +15,7 @@ type CompetitionResult struct {
 
 // ListCompetitions to get competitions associated with the markets selected by the filter
 func (b *Betting) ListCompetitions(filter Filter) (competitionResults []CompetitionResult, err error) {
-	err = b.Request(&competitionResults, BettingURL, "listCompetitions", &filter)
+	err = b.Request(&competitionResults, b.BettingURL, "listCompetitions", &filter)
 	if err != nil {
 		return
 	}
@@ -30,7 +30,7 @@ type CountryCodeResult struct {
 
 // ListCountries to get a list of countries associated with the markets selected by the filter
 func (b *Betting) ListCountries(filter Filter) (countryCodeResults []CountryCodeResult, err error) {
-	err = b.Request(&countryCodeResults, BettingURL, "listCountries", &filter)
+	err = b.Request(&countryCodeResults, b.BettingURL, "listCountries", &filter)
 	if err != nil {
 		return
 	}
@@ -73,7 +73,7 @@ type CurrentOrderSummaryReport struct {
 
 // ListCurrentOrders to get a list of your current orders
 func (b *Betting) ListCurrentOrders(filter Filter) (currentOrderSummaryReport CurrentOrderSummaryReport, err error) {
-	err = b.Request(&currentOrderSummaryReport, BettingURL, "listCurrentOrders", &filter)
+	err = b.Request(&currentOrderSummaryReport, b.BettingURL, "listCurrentOrders", &filter)
 	if err != nil {
 		return
 	}
@@ -126,7 +126,7 @@ type ClearedOrderSummaryReport struct {
 
 // ListClearedOrders to get a list of settled bets based on the bet status, ordered by settled date
 func (b *Betting) ListClearedOrders(filter Filter) (clearedOrderSummaryReport ClearedOrderSummaryReport, err error) {
-	err = b.Request(&clearedOrderSummaryReport, BettingURL, "listClearedOrders", &filter)
+	err = b.Request(&clearedOrderSummaryReport, b.BettingURL, "listClearedOrders", &filter)
 	if err != nil {
 		return
 	}
@@ -150,7 +150,7 @@ type EventResult struct {
 
 // ListEvents to get a list of all events
 func (b *Betting) ListEvents(filter Filter) (eventResult []EventResult, err error) {
-	err = b.Request(&eventResult, BettingURL, "listEvents", &filter)
+	err = b.Request(&eventResult, b.BettingURL, "listEvents", &filter)
 	if err != nil {
 		return
 	}
@@ -170,7 +170,7 @@ type EventTypeResult struct {
 
 // ListEventTypes to get a list of all event types
 func (b *Betting) ListEventTypes(filter Filter) (eventTypeResult []EventTypeResult, err error) {
-	err = b.Request(&eventTypeResult, BettingURL, "listEventTypes", &filter)
+	err = b.Request(&eventTypeResult, b.BettingURL, "listEventTypes", &filter)
 	if err != nil {
 		return
 	}
@@ -219,7 +219,7 @@ type RunnerCatalog struct {
 
 // ListMarketCatalogue to get a list of information about published (ACTIVE/SUSPENDED) markets that does not change (or changes very rarely).
 func (b *Betting) ListMarketCatalogue(filter Filter) (marketCatalogue []MarketCatalogue, err error) {
-	err = b.Request(&marketCatalogue, BettingURL, "listMarketCatalogue", &filter)
+	err = b.Request(&marketCatalogue, b.BettingURL, "listMarketCatalogue", &filter)
 	if err != nil {
 		return
 	}
@@ -276,12 +276,14 @@ type ExchangePrices struct {
 	TradedVolume    []PriceSize `json:"tradedVolume,omitempty"`
 }
 
-type Order struct { /* TODO: Implement */ }
-type Match struct { /* TODO: Implement */ }
+type Order struct { /* TODO: Implement */
+}
+type Match struct { /* TODO: Implement */
+}
 
 // ListMarketBook to get a list of dynamic data about markets.
 func (b *Betting) ListMarketBook(filter Filter) (marketBook []MarketBook, err error) {
-	err = b.Request(&marketBook, BettingURL, "listMarketBook", &filter)
+	err = b.Request(&marketBook, b.BettingURL, "listMarketBook", &filter)
 
 	return
 }
@@ -301,7 +303,7 @@ type RunnerProfitAndLoss struct {
 
 // ListMarketProfitAndLoss Retrieve profit and loss for a given list of OPEN markets.
 func (b *Betting) ListMarketProfitAndLoss(filter Filter) (marketProfitAndLoss []MarketProfitAndLoss, err error) {
-	err = b.Request(&marketProfitAndLoss, BettingURL, "listMarketProfitAndLoss", &filter)
+	err = b.Request(&marketProfitAndLoss, b.BettingURL, "listMarketProfitAndLoss", &filter)
 	if err != nil {
 		return
 	}
@@ -316,7 +318,7 @@ type MarketTypeResult struct {
 
 // ListMarketTypes to get a list of market types (i.e. MATCH_ODDS, NEXT_GOAL) associated with the markets selected by the MarketFilter.
 func (b *Betting) ListMarketTypes(filter Filter) (marketTypeResult []MarketTypeResult, err error) {
-	err = b.Request(&marketTypeResult, BettingURL, "listMarketTypes", &filter)
+	err = b.Request(&marketTypeResult, b.BettingURL, "listMarketTypes", &filter)
 	if err != nil {
 		return
 	}
@@ -331,7 +333,7 @@ type TimeRangeResult struct {
 
 // ListTimeRangeResult to get  a list of time ranges in the granularity specified in the request (i.e. 3PM to 4PM, Aug 14th to Aug 15th) associated with the markets selected by the MarketFilter.
 func (b *Betting) ListTimeRangeResult(filter Filter) (timeRangeResult []TimeRangeResult, err error) {
-	err = b.Request(&timeRangeResult, BettingURL, "listTimeRanges", &filter)
+	err = b.Request(&timeRangeResult, b.BettingURL, "listTimeRanges", &filter)
 	if err != nil {
 		return
 	}
@@ -346,7 +348,7 @@ type VenueResult struct {
 
 // ListVenueResult to get a list of Venues (i.e. Cheltenham, Ascot) associated with the markets selected by the MarketFilter. Currently, only Horse Racing markets are associated with a Venue.
 func (b *Betting) ListVenueResult(filter Filter) (venueResult []VenueResult, err error) {
-	err = b.Request(&venueResult, BettingURL, "listVenues", &filter)
+	err = b.Request(&venueResult, b.BettingURL, "listVenues", &filter)
 	if err != nil {
 		return
 	}

--- a/betting_order.go
+++ b/betting_order.go
@@ -1,26 +1,25 @@
 package betting
 
 import (
-	"time"
 	"fmt"
+	"time"
 )
-
 
 type Decimal float64
 
 func (n Decimal) MarshalJSON() ([]byte, error) {
-    return []byte(fmt.Sprintf("%.2f", n)), nil
+	return []byte(fmt.Sprintf("%.2f", n)), nil
 }
 
 type PlaceInstruction struct {
-	OrderType          EOrderType         `json:"orderType,omitempty"`
-	SelectionID        int64              `json:"selectionId,omitempty"`
-	Handicap           Decimal            `json:"handicap,omitempty"`
-	Side               ESide              `json:"side,omitempty"`
+	OrderType          EOrderType          `json:"orderType,omitempty"`
+	SelectionID        int64               `json:"selectionId,omitempty"`
+	Handicap           Decimal             `json:"handicap,omitempty"`
+	Side               ESide               `json:"side,omitempty"`
 	LimitOrder         *LimitOrder         `json:"limitOrder,omitempty"`
 	LimitOnCloseOrder  *LimitOnCloseOrder  `json:"limitOnCloseOrder,omitempty"`
 	MarketOnCloseOrder *MarketOnCloseOrder `json:"marketOnCloseOrder,omitempty"`
-	CustomerOrderRef   string             `json:"customerOrderRef,omitempty"`
+	CustomerOrderRef   string              `json:"customerOrderRef,omitempty"`
 }
 
 type PlaceExecutionReport struct {
@@ -63,7 +62,7 @@ type MarketOnCloseOrder struct {
 
 // PlaceOrders to place new orders into market.
 func (b *Betting) PlaceOrders(filter Filter) (placeExecutionReport PlaceExecutionReport, err error) {
-	err = b.Request(&placeExecutionReport, BettingURL, "placeOrders", &filter)
+	err = b.Request(&placeExecutionReport, b.BettingURL, "placeOrders", &filter)
 	if err != nil {
 		return
 	}
@@ -71,10 +70,9 @@ func (b *Betting) PlaceOrders(filter Filter) (placeExecutionReport PlaceExecutio
 	return
 }
 
-
-type	CancelInstruction	struct	{
-	BetID          string         `json:"betId"`
-	SizeReduction  Decimal        `json:"sizeReduction,omitempty"`
+type CancelInstruction struct {
+	BetID         string  `json:"betId"`
+	SizeReduction Decimal `json:"sizeReduction,omitempty"`
 }
 
 type CancelExecutionReport struct {
@@ -82,20 +80,20 @@ type CancelExecutionReport struct {
 	Status             EExecutionReportStatus    `json:"status,omitempty"`
 	ErrorCode          EExecutionReportErrorCode `json:"errorCode,omitempty"`
 	MarketID           string                    `json:"marketId,omitempty"`
-	InstructionReports []CancelInstructionReport  `json:"instructionReports,omitempty"`
+	InstructionReports []CancelInstructionReport `json:"instructionReports,omitempty"`
 }
 
 type CancelInstructionReport struct {
-	Status              EInstructionReportStatus    `json:"status,omitempty"`
-	ErrorCode           EInstructionReportErrorCode `json:"errorCode,omitempty"`
-	Instruction         CancelInstruction            `json:"instruction,omitempty"`
-	CancelledDate       time.Time                   `json:"cancelledDate,omitempty"`
-	SizeCancelled       float64                     `json:"sizeCancelled,omitempty"`
+	Status        EInstructionReportStatus    `json:"status,omitempty"`
+	ErrorCode     EInstructionReportErrorCode `json:"errorCode,omitempty"`
+	Instruction   CancelInstruction           `json:"instruction,omitempty"`
+	CancelledDate time.Time                   `json:"cancelledDate,omitempty"`
+	SizeCancelled float64                     `json:"sizeCancelled,omitempty"`
 }
 
 // CancelOrders to place new orders into market.
 func (b *Betting) CancelOrders(filter CancelFilter) (cancelExecutionReport CancelExecutionReport, err error) {
-	err = b.Request(&cancelExecutionReport, BettingURL, "cancelOrders", &filter)
+	err = b.Request(&cancelExecutionReport, b.BettingURL, "cancelOrders", &filter)
 	if err != nil {
 		return
 	}

--- a/betting_order_test.go
+++ b/betting_order_test.go
@@ -23,7 +23,7 @@ func TestRequestPlaceOrders(t *testing.T) {
 				Side:        S_LAY,
 				Handicap:    0,
 				OrderType:   OT_MARKET_ON_CLOSE,
-				MarketOnCloseOrder: MarketOnCloseOrder{
+				MarketOnCloseOrder: &MarketOnCloseOrder{
 					Liability: 1,
 				},
 			},

--- a/session.go
+++ b/session.go
@@ -10,8 +10,10 @@ import (
 )
 
 type Client struct {
-	ApiKey     string
-	SessionKey string
+	ApiKey       string
+	SessionKey   string
+	CertURL      BetfairRestURL
+	KeepAliveURL BetfairRestURL
 }
 
 type Session struct {
@@ -25,7 +27,7 @@ func (c *Client) GetSessionFromCertificate(cert tls.Certificate, login, password
 	client := fasthttp.Client{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}, InsecureSkipVerify: true}}
 
 	req, resp := fasthttp.AcquireRequest(), fasthttp.AcquireResponse()
-	req.SetRequestURI(CertURL)
+	req.SetRequestURI(string(c.CertURL))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("X-Application", c.ApiKey)
 	req.Header.SetMethod("POST")
@@ -79,7 +81,7 @@ func (c *Client) KeepAlive() error {
 	var keepAlive *KeepAlive = &KeepAlive{}
 
 	req, resp := fasthttp.AcquireRequest(), fasthttp.AcquireResponse()
-	req.SetRequestURI(KeepAliveURL)
+	req.SetRequestURI(string(c.KeepAliveURL))
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Application", c.ApiKey)
 	req.Header.Set("X-Authentication", c.SessionKey)


### PR DESCRIPTION
This change lets you pass in custom URLs for Betfair endpoints (eg: to allow the use of staging environments, mocking, etc). The change is backwards compatible with the existing codebase as the default URLs haven't changed and the existing method passes them in as before.

A new method has been added to allow you to specify the URLs to use to talk to Betfair (`NewBetfairWithSpecifiedURLs`)